### PR TITLE
feat: Allow to pass custom instance of `RawPropsParser` to `ComponentDescriptor`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.cpp
@@ -29,7 +29,7 @@ Props::Shared UnimplementedViewComponentDescriptor::cloneProps(
   // We have to clone `Props` object one more time to make sure that we have
   // an unshared (and non-`const`) copy of it which we can mutate.
   RawProps emptyRawProps{};
-  emptyRawProps.parse(rawPropsParser_);
+  emptyRawProps.parse(*rawPropsParser_);
   auto unimplementedViewProps = std::make_shared<UnimplementedViewProps>(
       context,
       static_cast<const UnimplementedViewProps&>(*clonedProps),

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
@@ -12,7 +12,7 @@ namespace facebook::react {
 
 ComponentDescriptor::ComponentDescriptor(
     const ComponentDescriptorParameters& parameters,
-    RawPropsParser rawPropsParser)
+    std::unique_ptr<RawPropsParser> rawPropsParser)
     : eventDispatcher_(parameters.eventDispatcher),
       contextContainer_(parameters.contextContainer),
       flavor_(parameters.flavor),

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
@@ -11,10 +11,12 @@
 namespace facebook::react {
 
 ComponentDescriptor::ComponentDescriptor(
-    const ComponentDescriptorParameters& parameters)
+    const ComponentDescriptorParameters& parameters,
+    RawPropsParser rawPropsParser)
     : eventDispatcher_(parameters.eventDispatcher),
       contextContainer_(parameters.contextContainer),
-      flavor_(parameters.flavor) {}
+      flavor_(parameters.flavor),
+      rawPropsParser_(std::move(rawPropsParser)) {}
 
 const std::shared_ptr<const ContextContainer>&
 ComponentDescriptor::getContextContainer() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -46,7 +46,10 @@ class ComponentDescriptor {
    */
   using Flavor = std::shared_ptr<const void>;
 
-  ComponentDescriptor(const ComponentDescriptorParameters& parameters, RawPropsParser rawPropsParser = RawPropsParser());
+  ComponentDescriptor(
+      const ComponentDescriptorParameters& parameters,
+      std::unique_ptr<RawPropsParser> rawPropsParser =
+          std::make_unique<RawPropsParser>());
 
   virtual ~ComponentDescriptor() = default;
 
@@ -133,7 +136,7 @@ class ComponentDescriptor {
 
   EventDispatcher::Weak eventDispatcher_;
   std::shared_ptr<const ContextContainer> contextContainer_;
-  RawPropsParser rawPropsParser_;
+  std::unique_ptr<RawPropsParser> rawPropsParser_;
   Flavor flavor_;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -46,7 +46,7 @@ class ComponentDescriptor {
    */
   using Flavor = std::shared_ptr<const void>;
 
-  ComponentDescriptor(const ComponentDescriptorParameters& parameters);
+  ComponentDescriptor(const ComponentDescriptorParameters& parameters, RawPropsParser rawPropsParser = RawPropsParser());
 
   virtual ~ComponentDescriptor() = default;
 
@@ -133,7 +133,7 @@ class ComponentDescriptor {
 
   EventDispatcher::Weak eventDispatcher_;
   std::shared_ptr<const ContextContainer> contextContainer_;
-  RawPropsParser rawPropsParser_{};
+  RawPropsParser rawPropsParser_;
   Flavor flavor_;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -49,7 +49,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   ConcreteComponentDescriptor(
       const ComponentDescriptorParameters& parameters,
       RawPropsParser rawPropsParser = RawPropsParser())
-      : ComponentDescriptor(parameters, rawPropsParser) {
+      : ComponentDescriptor(parameters, std::move(rawPropsParser)) {
     rawPropsParser_.prepare<ConcreteProps>();
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -46,8 +46,10 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   using ConcreteState = typename ShadowNodeT::ConcreteState;
   using ConcreteStateData = typename ShadowNodeT::ConcreteState::Data;
 
-  ConcreteComponentDescriptor(const ComponentDescriptorParameters& parameters)
-      : ComponentDescriptor(parameters) {
+  ConcreteComponentDescriptor(
+      const ComponentDescriptorParameters& parameters,
+      RawPropsParser rawPropsParser = RawPropsParser())
+      : ComponentDescriptor(parameters, rawPropsParser) {
     rawPropsParser_.prepare<ConcreteProps>();
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -48,9 +48,10 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
 
   ConcreteComponentDescriptor(
       const ComponentDescriptorParameters& parameters,
-      RawPropsParser rawPropsParser = RawPropsParser())
+      std::unique_ptr<RawPropsParser> rawPropsParser =
+          std::make_unique<RawPropsParser>())
       : ComponentDescriptor(parameters, std::move(rawPropsParser)) {
-    rawPropsParser_.prepare<ConcreteProps>();
+    rawPropsParser_->prepare<ConcreteProps>();
   }
 
   ComponentHandle getComponentHandle() const override {
@@ -112,7 +113,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
       ShadowNodeT::filterRawProps(rawProps);
     }
 
-    rawProps.parse(rawPropsParser_);
+    rawProps.parse(*rawPropsParser_);
 
     // Use the new-style iterator
     // Note that we just check if `Props` has this flag set, no matter

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -138,7 +138,7 @@ void RawPropsParser::preparse(const RawProps& rawProps) const noexcept {
 
         auto value = object.getProperty(runtime, nameValue);
         RawValue rawValue;
-        if (ReactNativeFeatureFlags::useRawPropsJsiValue()) {
+        if (ReactNativeFeatureFlags::useRawPropsJsiValue() || useRawJsiProps_) {
           rawValue = RawValue(runtime, std::move(value));
         } else {
           rawValue = RawValue(jsi::dynamicFromValue(runtime, value));

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -27,7 +27,8 @@ class RawPropsParser final {
    * Default constructor.
    * To be used by `ConcreteComponentDescriptor` only.
    */
-  RawPropsParser() = default;
+  RawPropsParser(bool useRawJsiProps = false)
+      : useRawJsiProps_(useRawJsiProps) {};
 
   /*
    * To be used by `ConcreteComponentDescriptor` only.
@@ -56,6 +57,7 @@ class RawPropsParser final {
   template <class ShadowNodeT>
   friend class ConcreteComponentDescriptor;
   friend class RawProps;
+  bool useRawJsiProps_;
 
   /*
    * To be used by `RawProps` only.

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -21,7 +21,7 @@ namespace facebook::react {
  * Specialized (to a particular type of Props) parser that provides the most
  * efficient access to `RawProps` content.
  */
-class RawPropsParser final {
+class RawPropsParser {
  public:
   /*
    * Default constructor.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

> [!WARNING]
> Based on the following PR which should be merged first;
> - https://github.com/facebook/react-native/pull/48047

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In https://github.com/facebook/react-native/pull/48047 we introduced a way to change how the `RawPropParser` creates `RawValue`s, by allowing to pass jsi values directly.

This change enables to test the alternative prop parsing on a component by component basis. You can pass a flag to `RawPropParser` to enable the alternative prop parsing (the default option is `false`).
Component can now pass their own `RawPropsParser` instance to their `ConcreteComponentProvider` with that flag enabled.

Additionally we removed the `final` from `RawPropsParser`, which allows us to experiment with alternative implementation for the `RawPropsParser` (can also be moved to a separate PR ofc)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [ADDED] - Make `RawPropsParser` configurable and passable to `ConcreteComponentProvider`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Make sure rn-tester app is still functioning.
